### PR TITLE
WIP: fixes for alice/bob confusion, http codes and prefixes on directories

### DIFF
--- a/test/surface/create.test.ts
+++ b/test/surface/create.test.ts
@@ -199,7 +199,7 @@ describe('Create', () => {
       });
       expect(result.status).toEqual(201);
     });
-    it(`is disallowed without default Write or Append`, async () => {
+    it(`is disallowed without default Write`, async () => {
       const containerUrl = `${testFolderUrl}6/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
@@ -213,7 +213,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -230,8 +230,7 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it.skip(`is disallowed without accessTo Write or Append`, async () => {
-      // FIXME: if the default grants on the container allow write/append, the put should succeed?
+    it(`is disallowed without accessTo Write or Append`, async () => {
       const containerUrl = `${testFolderUrl}7/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
@@ -353,8 +352,7 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it.skip(`is disallowed without accessTo Write or Append`, async () => {
-      // FIXME: if the default grants on the container allow write/append, the put should succeed?
+    it(`is disallowed without accessTo Write or Append`, async () => {
       const containerUrl = `${testFolderUrl}11/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
@@ -447,7 +445,7 @@ describe('Create', () => {
       });
       expect(result.status).toEqual(201);
     });
-    it(`is disallowed without default Write or Append`, async () => {
+    it(`is disallowed without default Write`, async () => {
       const containerUrl = `${testFolderUrl}14/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
@@ -461,7 +459,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -478,9 +476,7 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it.skip(`is disallowed without accessTo Write or Append`, async () => {
-      // FIXME: if the default grants on the container allow write/append, the put should succeed?
-
+    it(`is disallowed without accessTo Write or Append`, async () => {
       const containerUrl = `${testFolderUrl}15/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
@@ -602,8 +598,7 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it.skip(`is disallowed without accessTo Write or Append`, async () => {
-      // FIXME: if the default for containerUrl is 'append' and 'write', why should it be disallowed on containerUrl/nested/ ?
+    it(`is disallowed without accessTo Write or Append`, async () => {
       const containerUrl = `${testFolderUrl}19/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {

--- a/test/surface/create.test.ts
+++ b/test/surface/create.test.ts
@@ -314,11 +314,10 @@ describe('Create', () => {
         }
       });
       const result = await solidLogicBob.fetch(`${containerUrl}new.txt`, {
-        method: 'PUT',
-        body: 'hello',
+        method: 'PATCH',
+        body: 'INSERT { <#hello> <#linked> <#world> . }',
         headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
+          'Content-Type': 'application/sparql-update'
         }
       });
       expect(result.status).toEqual(201);
@@ -344,11 +343,10 @@ describe('Create', () => {
         }
       });
       const result = await solidLogicBob.fetch(`${containerUrl}new.txt`, {
-        method: 'PUT',
-        body: 'hello',
+        method: 'PATCH',
+        body: 'INSERT { <#hello> <#linked> <#world> . }',
         headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
+          'Content-Type': 'application/sparql-update'
         }
       });
       expect(result.status).toEqual(403);
@@ -375,11 +373,10 @@ describe('Create', () => {
         }
       });
       const result = await solidLogicBob.fetch(`${containerUrl}new.txt`, {
-        method: 'PUT',
-        body: 'hello',
+        method: 'PATCH',
+        body: 'INSERT { <#hello> <#linked> <#world> . }',
         headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
+          'Content-Type': 'application/sparql-update'
         }
       });
       expect(result.status).toEqual(403);
@@ -563,11 +560,10 @@ describe('Create', () => {
         }
       });
       const result = await solidLogicBob.fetch(`${containerUrl}nested/new.txt`, {
-        method: 'PUT',
-        body: 'hello',
+        method: 'PATCH',
+        body: 'INSERT { <#hello> <#linked> <#world> . }',
         headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
+          'Content-Type': 'application/sparql-update'
         }
       });
       expect(result.status).toEqual(201);
@@ -593,11 +589,10 @@ describe('Create', () => {
         }
       });
       const result = await solidLogicBob.fetch(`${containerUrl}nested/new.txt`, {
-        method: 'PUT',
-        body: 'hello',
+        method: 'PATCH',
+        body: 'INSERT { <#hello> <#linked> <#world> . }',
         headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
+          'Content-Type': 'application/sparql-update'
         }
       });
       expect(result.status).toEqual(403);
@@ -624,11 +619,10 @@ describe('Create', () => {
         }
       });
       const result = await solidLogicBob.fetch(`${containerUrl}nested/new.txt`, {
-        method: 'PUT',
-        body: 'hello',
+        method: 'PATCH',
+        body: 'INSERT { <#hello> <#linked> <#world> . }',
         headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
+          'Content-Type': 'application/sparql-update'
         }
       });
       expect(result.status).toEqual(403);

--- a/test/surface/create.test.ts
+++ b/test/surface/create.test.ts
@@ -39,7 +39,7 @@ describe('Create', () => {
     solidLogicAlice = await getSolidLogicInstance('ALICE')
     solidLogicBob = await getSolidLogicInstance('BOB')
   });
-  
+
   const { testFolderUrl } = generateTestFolder('ALICE');
   beforeEach(async () => {
     // FIXME: NSS ACL cache,
@@ -53,7 +53,7 @@ describe('Create', () => {
 
   describe('Using POST to existing container', () => {
     it(`Is allowed with accessTo Append access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAppend/`;
+      const containerUrl = `${testFolderUrl}1/accessToAppend/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -72,7 +72,7 @@ describe('Create', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicBob.fetch(`${testFolderUrl}accessToAppend/`, {
+      const result = await solidLogicBob.fetch(`${testFolderUrl}1/accessToAppend/`, {
         method: 'POST',
         body: 'hello',
         headers: {
@@ -82,7 +82,7 @@ describe('Create', () => {
       expect(result.status).toEqual(201);
     });
     it(`Is allowed with accessTo Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToWrite/`;
+      const containerUrl = `${testFolderUrl}2/accessToWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -101,14 +101,14 @@ describe('Create', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicBob.fetch(`${testFolderUrl}accessToWrite/`, {
+      const result = await solidLogicBob.fetch(`${testFolderUrl}2/accessToWrite/`, {
         method: 'POST',
         body: 'hello'
       });
       expect(result.status).toEqual(201);
     });
     it(`Is disallowed otherwise`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+      const containerUrl = `${testFolderUrl}3/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -140,7 +140,7 @@ describe('Create', () => {
 
   describe('Using PUT in existing container', () => {
     it(`Is allowed with accessTo Write and default Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      const containerUrl = `${testFolderUrl}4/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -170,7 +170,7 @@ describe('Create', () => {
       expect(result.status).toEqual(201);
     });
     it(`Is allowed with accessTo Append and default Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      const containerUrl = `${testFolderUrl}5/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -199,8 +199,8 @@ describe('Create', () => {
       });
       expect(result.status).toEqual(201);
     });
-    it(`is disallowed without default Write`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+    it(`is disallowed without default Write or Append`, async () => {
+      const containerUrl = `${testFolderUrl}6/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -213,7 +213,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -230,8 +230,9 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it(`is disallowed without accessTo Write or Append`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+    it.skip(`is disallowed without accessTo Write or Append`, async () => {
+      // FIXME: if the default grants on the container allow write/append, the put should succeed?
+      const containerUrl = `${testFolderUrl}7/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -244,7 +245,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -265,7 +266,7 @@ describe('Create', () => {
 
   describe('Using PATCH in existing container', () => {
     it(`Is allowed with accessTo Write and default Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      const containerUrl = `${testFolderUrl}8/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -294,7 +295,7 @@ describe('Create', () => {
       expect(result.status).toEqual(201);
     });
     it(`Is allowed with accessTo Append and default Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      const containerUrl = `${testFolderUrl}9/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -323,7 +324,7 @@ describe('Create', () => {
       expect(result.status).toEqual(201);
     });
     it(`is disallowed without default Write`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+      const containerUrl = `${testFolderUrl}10/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -336,7 +337,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -352,8 +353,9 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it(`is disallowed without accessTo Write or Append`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+    it.skip(`is disallowed without accessTo Write or Append`, async () => {
+      // FIXME: if the default grants on the container allow write/append, the put should succeed?
+      const containerUrl = `${testFolderUrl}11/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -366,7 +368,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -386,7 +388,7 @@ describe('Create', () => {
 
   describe('Using PUT in non-existing container', () => {
     it(`Is allowed with accessTo Write and default Write access`, async () => {
-      let containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      let containerUrl = `${testFolderUrl}12/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -416,7 +418,7 @@ describe('Create', () => {
       expect(result.status).toEqual(201);
     });
     it(`Is allowed with accessTo Append and default Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      const containerUrl = `${testFolderUrl}13/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -445,8 +447,8 @@ describe('Create', () => {
       });
       expect(result.status).toEqual(201);
     });
-    it(`is disallowed without default Write`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+    it(`is disallowed without default Write or Append`, async () => {
+      const containerUrl = `${testFolderUrl}14/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -459,7 +461,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -476,8 +478,10 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it(`is disallowed without accessTo Write or Append`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+    it.skip(`is disallowed without accessTo Write or Append`, async () => {
+      // FIXME: if the default grants on the container allow write/append, the put should succeed?
+
+      const containerUrl = `${testFolderUrl}15/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -490,7 +494,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -511,7 +515,7 @@ describe('Create', () => {
 
   describe('Using PATCH in non-existing container', () => {
     it(`Is allowed with accessTo Write and default Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      const containerUrl = `${testFolderUrl}16/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -540,7 +544,7 @@ describe('Create', () => {
       expect(result.status).toEqual(201);
     });
     it(`Is allowed with accessTo Append and default Write access`, async () => {
-      const containerUrl = `${testFolderUrl}accessToAndDefaultWrite/`;
+      const containerUrl = `${testFolderUrl}17/accessToAndDefaultWrite/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -569,7 +573,7 @@ describe('Create', () => {
       expect(result.status).toEqual(201);
     });
     it(`is disallowed without default Write`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+      const containerUrl = `${testFolderUrl}18/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -582,7 +586,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Write, acl:Control', 'acl:Read, acl:Append, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -598,8 +602,9 @@ describe('Create', () => {
       expect(result.status).toEqual(403);
     });
 
-    it(`is disallowed without accessTo Write or Append`, async () => {
-      const containerUrl = `${testFolderUrl}allOtherModes/`;
+    it.skip(`is disallowed without accessTo Write or Append`, async () => {
+      // FIXME: if the default for containerUrl is 'append' and 'write', why should it be disallowed on containerUrl/nested/ ?
+      const containerUrl = `${testFolderUrl}19/allOtherModes/`;
       // This will do mkdir-p:
       await solidLogicAlice.fetch(`${containerUrl}test.txt`, {
         method: 'PUT',
@@ -612,7 +617,7 @@ describe('Create', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body:  makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
+        body: makeBody('acl:Read, acl:Control', 'acl:Read, acl:Append, acl:Write, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -627,6 +632,5 @@ describe('Create', () => {
       });
       expect(result.status).toEqual(403);
     });
-
   });
 });

--- a/test/surface/delete.test.ts
+++ b/test/surface/delete.test.ts
@@ -119,7 +119,7 @@ describe('Delete', () => {
     const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
     await solidLogicAlice.fetch(aclDocUrl, {
       method: 'PUT',
-      body: makeBody(null, 'acl:Write', resourceUrl),
+      body: makeBody(null, 'acl:Write', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
         'If-None-Match': '*'

--- a/test/surface/delete.test.ts
+++ b/test/surface/delete.test.ts
@@ -53,7 +53,7 @@ describe('Delete', () => {
   });
 
   it('Is allowed with accessTo Write access on resource', async () => {
-    const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
+    const resourceUrl = `${testFolderUrl}1/accessToAppend/test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
       method: 'PUT',
@@ -72,13 +72,14 @@ describe('Delete', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl, {
+    const result = await solidLogicBob.fetch(resourceUrl, {
       method: 'DELETE'
     });
     expect(responseCodeGroup(result.status)).toEqual("2xx");
   });
+
   it('Is disallowed with accessTo Read+Append+Control access on resource', async () => {
-    const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
+    const resourceUrl = `${testFolderUrl}2/accessToAppend/test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
       method: 'PUT',
@@ -97,13 +98,14 @@ describe('Delete', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl, {
+    const result = await solidLogicBob.fetch(resourceUrl, {
       method: 'DELETE'
     });
-    expect(responseCodeGroup(result.status)).toEqual("2xx");
+    expect(result.status).toEqual(403);
   });
+
   it('Is allowed with default Write access on parent', async () => {
-    const containerUrl = `${testFolderUrl}accessToAppend/`;
+    const containerUrl = `${testFolderUrl}3/accessToAppend/`;
     const resourceUrl = `${containerUrl}test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
@@ -123,13 +125,14 @@ describe('Delete', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl, {
+    const result = await solidLogicBob.fetch(resourceUrl, {
       method: 'DELETE'
     });
     expect(responseCodeGroup(result.status)).toEqual("2xx");
   });
+
   it('Is disallowed with default Read+Append+Control access on parent', async () => {
-    const containerUrl = `${testFolderUrl}accessToAppend/`;
+    const containerUrl = `${testFolderUrl}4/accessToAppend/`;
     const resourceUrl = `${containerUrl}test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
@@ -151,7 +154,7 @@ describe('Delete', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl, {
+    const result = await solidLogicBob.fetch(resourceUrl, {
       method: 'DELETE'
     });
     expect(result.status).toEqual(403);

--- a/test/surface/read.test.ts
+++ b/test/surface/read.test.ts
@@ -200,7 +200,7 @@ describe('Read', () => {
     const containerUrl = `${testFolderUrl}7/accessToAppend/`;
     const resourceUrl = `${containerUrl}test/`;
     // This will do mkdir-p:
-    const creationResult =  await solidLogicAlice.fetch(`${resourceUrl}dummy`, {
+    const creationResult =  await solidLogicAlice.fetch(`${resourceUrl}.dummy`, {
       method: 'PUT',
       body: '<#hello> <#linked> <#world> .',
       headers: {

--- a/test/surface/read.test.ts
+++ b/test/surface/read.test.ts
@@ -114,7 +114,7 @@ describe('Read', () => {
     const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
     await solidLogicAlice.fetch(aclDocUrl, {
       method: 'PUT',
-      body: makeBody(null, 'acl:Read', resourceUrl),
+      body: makeBody(null, 'acl:Read', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
         'If-None-Match': '*'
@@ -211,7 +211,7 @@ describe('Read', () => {
     const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
     await solidLogicAlice.fetch(aclDocUrl, {
       method: 'PUT',
-      body: makeBody(null, 'acl:Read', resourceUrl),
+      body: makeBody(null, 'acl:Read', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
         'If-None-Match': '*'

--- a/test/surface/read.test.ts
+++ b/test/surface/read.test.ts
@@ -51,9 +51,8 @@ describe('Read', () => {
   afterEach(() => {
     return solidLogicAlice.recursiveDelete(testFolderUrl);
   });
-
   it('Is allowed with accessTo Read access on non-container resource', async () => {
-    const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
+    const resourceUrl = `${testFolderUrl}1/accessToAppend/test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
       method: 'PUT',
@@ -72,11 +71,11 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
+    const result = await solidLogicBob.fetch(resourceUrl);
     expect(responseCodeGroup(result.status)).toEqual("2xx");
   });
   it('Is disallowed with accessTo Append+Write+Control access on non-container resource', async () => {
-    const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
+    const resourceUrl = `${testFolderUrl}2/accessToAppend/test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
       method: 'PUT',
@@ -97,11 +96,11 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
-    expect(responseCodeGroup(result.status)).toEqual("2xx");
+    const result = await solidLogicBob.fetch(resourceUrl);
+    expect(result.status).toEqual(403);
   });
   it('Is allowed with default Read access on parent of non-container', async () => {
-    const containerUrl = `${testFolderUrl}accessToAppend/`;
+    const containerUrl = `${testFolderUrl}3/accessToAppend/`;
     const resourceUrl = `${containerUrl}test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
@@ -121,11 +120,11 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
+    const result = await solidLogicBob.fetch(resourceUrl);
     expect(responseCodeGroup(result.status)).toEqual("2xx");
   });
   it('Is disallowed with default Append+Write+Control access on parent of non-container', async () => {
-    const containerUrl = `${testFolderUrl}accessToAppend/`;
+    const containerUrl = `${testFolderUrl}4/accessToAppend/`;
     const resourceUrl = `${containerUrl}test.txt`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
@@ -145,12 +144,12 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
+    const result = await solidLogicBob.fetch(resourceUrl);
     expect(result.status).toEqual(403);
   });
 
   it('Is allowed with accessTo Read access on container resource', async () => {
-    const resourceUrl = `${testFolderUrl}accessToAppend/test/`;
+    const resourceUrl = `${testFolderUrl}5/accessToAppend/test/`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(`${resourceUrl}.dummy`, {
       method: 'PUT',
@@ -169,11 +168,12 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
+    const result = await solidLogicBob.fetch(resourceUrl);
     expect(responseCodeGroup(result.status)).toEqual("2xx");
   });
+
   it('Is disallowed with accessTo Append+Write+Control access on non-container resource', async () => {
-    const resourceUrl = `${testFolderUrl}accessToAppend/test/`;
+    const resourceUrl = `${testFolderUrl}6/accessToAppend/test/`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(`${resourceUrl}.dummy`, {
       method: 'PUT',
@@ -192,14 +192,15 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
-    expect(responseCodeGroup(result.status)).toEqual("2xx");
+    const result = await solidLogicBob.fetch(resourceUrl);
+    expect(result.status).toEqual(403);
   });
+
   it('Is allowed with default Read access on parent of container', async () => {
-    const containerUrl = `${testFolderUrl}accessToAppend/`;
+    const containerUrl = `${testFolderUrl}7/accessToAppend/`;
     const resourceUrl = `${containerUrl}test/`;
     // This will do mkdir-p:
-    const creationResult =  await solidLogicAlice.fetch(`${resourceUrl}.dummy`, {
+    const creationResult =  await solidLogicAlice.fetch(`${resourceUrl}dummy`, {
       method: 'PUT',
       body: '<#hello> <#linked> <#world> .',
       headers: {
@@ -216,11 +217,12 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
+    const result = await solidLogicBob.fetch(resourceUrl);
     expect(responseCodeGroup(result.status)).toEqual("2xx");
   });
+
   it('Is disallowed with default Append+Write+Control access on parent of non-container', async () => {
-    const containerUrl = `${testFolderUrl}accessToAppend/`;
+    const containerUrl = `${testFolderUrl}8/accessToAppend/`;
     const resourceUrl = `${containerUrl}test/`;
     // This will do mkdir-p:
     const creationResult =  await solidLogicAlice.fetch(`${resourceUrl}.dummy`, {
@@ -240,7 +242,8 @@ describe('Read', () => {
         'If-None-Match': '*'
       }
     });
-    const result = await solidLogicAlice.fetch(resourceUrl);
+    const result = await solidLogicBob.fetch(resourceUrl);
     expect(result.status).toEqual(403);
   });
+
 });

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -283,7 +283,7 @@ describe('Update', () => {
       });
       expect(responseCodeGroup(result.status)).toEqual("2xx");
     });
-    it('Is disallowed with accessTo Read+Control access on resource', async () => {
+    it('Is disallowed with accessTo Read+Append+Control access on resource', async () => {
       const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
       // This will do mkdir-p:
       const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
@@ -299,7 +299,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(resourceUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody('acl:Read, acl:Control', null, resourceUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Control', null, resourceUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -348,7 +348,7 @@ describe('Update', () => {
       });
       expect(responseCodeGroup(result.status)).toEqual("2xx");
     });
-    it('Is disallowed with default Read+Control access on parent', async () => {
+    it('Is disallowed with default Read+Append+Control access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
       const resourceUrl = `${containerUrl}test.txt`;
       // This will do mkdir-p:
@@ -365,7 +365,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Read, acl:Control', resourceUrl),
+        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', resourceUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -166,7 +166,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Append', resourceUrl),
+        body: makeBody(null, 'acl:Append', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -199,7 +199,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Write', resourceUrl),
+        body: makeBody(null, 'acl:Write', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -332,7 +332,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Write', resourceUrl),
+        body: makeBody(null, 'acl:Write', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -492,7 +492,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Append', resourceUrl),
+        body: makeBody(null, 'acl:Append', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -524,7 +524,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Write', resourceUrl),
+        body: makeBody(null, 'acl:Write', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -653,7 +653,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Write', resourceUrl),
+        body: makeBody(null, 'acl:Write', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -75,7 +75,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'hello world',
         headers: {
@@ -107,7 +107,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'hello world',
         headers: {
@@ -139,7 +139,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'hello world',
         headers: {
@@ -147,7 +147,7 @@ describe('Update', () => {
           'If-Match': etagInQuotes
         }
       });
-      expect(responseCodeGroup(result.status)).toEqual("2xx");
+	  expect(result.status).toEqual(403);
     });
     it('Is allowed with default Append access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
@@ -172,7 +172,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'hello world',
         headers: {
@@ -205,7 +205,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'hello world',
         headers: {
@@ -238,7 +238,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'hello world',
         headers: {
@@ -273,7 +273,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'goodbye',
         headers: {
@@ -305,7 +305,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'goodbye',
         headers: {
@@ -313,7 +313,7 @@ describe('Update', () => {
           'If-Match': etagInQuotes
         }
       });
-      expect(responseCodeGroup(result.status)).toEqual("2xx");
+      expect(result.status).toEqual(403);
     });
     it('Is allowed with default Write access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
@@ -338,7 +338,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'goodbye',
         headers: {
@@ -371,7 +371,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PUT',
         body: 'goodbye',
         headers: {
@@ -404,7 +404,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'INSERT { <#how> <#are> <#you> . }',
         headers: {
@@ -435,7 +435,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'INSERT { <#how> <#are> <#you> . }',
         headers: {
@@ -466,14 +466,14 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'INSERT { <#how> <#are> <#you> . }',
         headers: {
           'Content-Type': 'application/sparql-update'
         }
       });
-      expect(responseCodeGroup(result.status)).toEqual("2xx");
+      expect(result.status).toEqual(403);
     });
     it('Is allowed with default Append access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
@@ -498,7 +498,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'INSERT { <#how> <#are> <#you> . }',
         headers: {
@@ -530,7 +530,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'INSERT { <#how> <#are> <#you> . }',
         headers: {
@@ -562,7 +562,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'INSERT { <#how> <#are> <#you> . }',
         headers: {
@@ -596,7 +596,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'DELETE { <#hello> <#linked> <#world> . }',
         headers: {
@@ -627,14 +627,14 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'DELETE { <#hello> <#linked> <#world> . }',
         headers: {
           'Content-Type': 'application/sparql-update'
         }
       });
-      expect(responseCodeGroup(result.status)).toEqual("2xx");
+      expect(result.status).toEqual(403);
     });
     it('Is allowed with default Write access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
@@ -659,7 +659,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'DELETE { <#hello> <#linked> <#world> . }',
         headers: {
@@ -691,7 +691,7 @@ describe('Update', () => {
           'If-None-Match': '*'
         }
       });
-      const result = await solidLogicAlice.fetch(resourceUrl, {
+      const result = await solidLogicBob.fetch(resourceUrl, {
         method: 'PATCH',
         body: 'DELETE { <#hello> <#linked> <#world> . }',
         headers: {

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -283,7 +283,7 @@ describe('Update', () => {
       });
       expect(responseCodeGroup(result.status)).toEqual("2xx");
     });
-    it('Is disallowed with accessTo Read+Append+Control access on resource', async () => {
+    it('Is disallowed with accessTo Read+Control access on resource', async () => {
       const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
       // This will do mkdir-p:
       const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
@@ -299,7 +299,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(resourceUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody('acl:Read, acl:Append, acl:Control', null, resourceUrl),
+        body: makeBody('acl:Read, acl:Control', null, resourceUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -348,7 +348,7 @@ describe('Update', () => {
       });
       expect(responseCodeGroup(result.status)).toEqual("2xx");
     });
-    it('Is disallowed with default Read+Append+Control access on parent', async () => {
+    it('Is disallowed with default Read+Control access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
       const resourceUrl = `${containerUrl}test.txt`;
       // This will do mkdir-p:
@@ -365,7 +365,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', resourceUrl),
+        body: makeBody(null, 'acl:Read, acl:Control', resourceUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -700,5 +700,6 @@ describe('Update', () => {
       });
       expect(result.status).toEqual(403);
     });
+
   });
 });


### PR DESCRIPTION
- fixed fetches that were done with Alice, which should have been Bob
- if the test is disallowed, it should check for a 403 result
- read/delete test directories are prefixed as a workaround for a problem where the recursive delete uses a cached version of the directory listing, so it fails to clean up for the next test

Feel free to mix and match :)