### PR TITLE
Fix error with missing argument

### DIFF
--- a/test/helpers/util.ts
+++ b/test/helpers/util.ts
@@ -24,7 +24,7 @@ export class WPSClient {
       // console.log('WS <', msg);
       this.received.push(msg);
     });  
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       this.ws.on('open', async () => {
         const authHeaders = await getAuthHeaders(this.resourceUrl, 'GET', this.authFetcher);
         await this.send(`sub ${this.resourceUrl}`);


### PR DESCRIPTION
Fixes this issue: test/helpers/util.ts:33:9 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?