### PR TITLE
remove Append success with PUT and edit PATCH success from 200 to 2xx

### DIFF
--- a/test/surface/create.test.ts
+++ b/test/surface/create.test.ts
@@ -1,5 +1,6 @@
 import { SolidLogic } from 'solid-logic';
 import { generateTestFolder, getSolidLogicInstance, WEBID_ALICE, WEBID_BOB } from '../helpers/env';
+import { responseCodeGroup } from '../helpers/util'
 
 function makeBody(accessToModes: string, defaultModes: string, target: string) {
   let str = [
@@ -291,7 +292,7 @@ describe('Create', () => {
           'Content-Type': 'application/sparql-update'
         }
       });
-      expect(result.status).toEqual(201);
+      expect(responseCodeGroup(result.status)).toEqual('2xx');
     });
     it(`Is allowed with accessTo Append and default Write access`, async () => {
       const containerUrl = `${testFolderUrl}9/accessToAndDefaultWrite/`;
@@ -320,7 +321,7 @@ describe('Create', () => {
           'Content-Type': 'application/sparql-update'
         }
       });
-      expect(result.status).toEqual(201);
+      expect(responseCodeGroup(result.status)).toEqual('2xx');
     });
     it(`is disallowed without default Write`, async () => {
       const containerUrl = `${testFolderUrl}10/allOtherModes/`;
@@ -537,7 +538,7 @@ describe('Create', () => {
           'Content-Type': 'application/sparql-update'
         }
       });
-      expect(result.status).toEqual(201);
+      expect(responseCodeGroup(result.status)).toEqual('2xx');
     });
     it(`Is allowed with accessTo Append and default Write access`, async () => {
       const containerUrl = `${testFolderUrl}17/accessToAndDefaultWrite/`;
@@ -566,7 +567,7 @@ describe('Create', () => {
           'Content-Type': 'application/sparql-update'
         }
       });
-      expect(result.status).toEqual(201);
+      expect(responseCodeGroup(result.status)).toEqual('2xx');
     });
     it(`is disallowed without default Write`, async () => {
       const containerUrl = `${testFolderUrl}18/allOtherModes/`;

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -53,38 +53,6 @@ describe('Update', () => {
   });
 
   describe('Using PUT to append', () => {
-    it('Is allowed with accessTo Append access on resource', async () => {
-      const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
-      // This will do mkdir-p:
-      const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
-        method: 'PUT',
-        body: 'hello',
-        headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
-        }
-      });
-      const etagInQuotes = creationResult.headers.get('etag');
-      // console.log({ etag: etagInQuotes });
-      const aclDocUrl = await solidLogicAlice.findAclDocUrl(resourceUrl);
-      await solidLogicAlice.fetch(aclDocUrl, {
-        method: 'PUT',
-        body: makeBody('acl:Append', null, resourceUrl),
-        headers: {
-          'Content-Type': 'text/turtle',
-          'If-None-Match': '*'
-        }
-      });
-      const result = await solidLogicBob.fetch(resourceUrl, {
-        method: 'PUT',
-        body: 'hello world',
-        headers: {
-          'Content-Type': 'text/plain',
-          'If-Match': etagInQuotes
-        }
-      });
-      expect(responseCodeGroup(result.status)).toEqual("2xx");
-    });
     it('Is allowed with accessTo Write access on resource', async () => {
       const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
       // This will do mkdir-p:
@@ -117,7 +85,7 @@ describe('Update', () => {
       });
       expect(responseCodeGroup(result.status)).toEqual("2xx");
     });
-    it('Is disallowed with accessTo Read+Control access on resource', async () => {
+    it('Is disallowed with accessTo Read+Append+Control access on resource', async () => {
       const resourceUrl = `${testFolderUrl}accessToAppend/test.txt`;
       // This will do mkdir-p:
       const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
@@ -133,7 +101,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(resourceUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody('acl:Read, acl:Control', null, resourceUrl),
+        body: makeBody('acl:Read, acl:Append, acl:Control', null, resourceUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -148,39 +116,6 @@ describe('Update', () => {
         }
       });
 	  expect(result.status).toEqual(403);
-    });
-    it('Is allowed with default Append access on parent', async () => {
-      const containerUrl = `${testFolderUrl}accessToAppend/`;
-      const resourceUrl = `${containerUrl}test.txt`;
-      // This will do mkdir-p:
-      const creationResult =  await solidLogicAlice.fetch(resourceUrl, {
-        method: 'PUT',
-        body: 'hello',
-        headers: {
-          'Content-Type': 'text/plain',
-          'If-None-Match': '*'
-        }
-      });
-      const etagInQuotes = creationResult.headers.get('etag');
-      // console.log({ etag: etagInQuotes });
-      const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
-      await solidLogicAlice.fetch(aclDocUrl, {
-        method: 'PUT',
-        body: makeBody(null, 'acl:Append', containerUrl),
-        headers: {
-          'Content-Type': 'text/turtle',
-          'If-None-Match': '*'
-        }
-      });
-      const result = await solidLogicBob.fetch(resourceUrl, {
-        method: 'PUT',
-        body: 'hello world',
-        headers: {
-          'Content-Type': 'text/plain',
-          'If-Match': etagInQuotes
-        }
-      });
-      expect(responseCodeGroup(result.status)).toEqual("2xx");
     });
     it('Is allowed with default Write access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
@@ -215,7 +150,7 @@ describe('Update', () => {
       });
       expect(responseCodeGroup(result.status)).toEqual("2xx");
     });
-    it('Is disallowed with default Read+Control access on parent', async () => {
+    it('Is disallowed with default Read+Append+Control access on parent', async () => {
       const containerUrl = `${testFolderUrl}accessToAppend/`;
       const resourceUrl = `${containerUrl}test.txt`;
       // This will do mkdir-p:
@@ -232,7 +167,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Read, acl:Control', resourceUrl),
+        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', resourceUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'


### PR DESCRIPTION
This is following the discussion on https://gitter.im/solid/test-suite
```
Alain Bourgeois
@bourgeoa
janv. 11 12:31

@csarven from the tests I see that update has 2 tests versions :

    append with a PUT to target URL requiring acl:Append with If-Match : etag on target, or acl:Write on parent
    overwrite with a PUT to target URL requiring acl:Write (to target or parent)

Is this correct ? What is the difference between URL exists and if-Match: etag
This append for PUT seems very new to me.
Yvo Brevoort
@ylebre
janv. 11 13:32
that is a weird one - you'd expect it to need 'Write' for that
but because the beginning of the file does not change, Append suffices
it is changed from 'hello' to 'hello world'
so it is treated as if the request only appends ' world' to the file
Sarven Capadisli
@csarven
janv. 11 14:33
PUT is a replace operation. Need Write. Append doesn't cut it.
Need Append/Write access on container in order to allocate the URI under that space.
```
and a new proposal to edit in tests the PATCH success to allow 2xx for 200 or 201, like in other places in the tests.