### PR TITLE
update tests : replace bad acls

### DIFF
--- a/example.sh
+++ b/example.sh
@@ -3,7 +3,7 @@ set -e
 
 # either test against a local server or in a container testnet
 #export SERVER_ROOT=https://localhost
-export SERVER_ROOT=https://alice.localhost:8443 #https://server
+export SERVER_ROOT=https://server
 export USERNAME_ALICE=alice
 export PASSWORD_ALICE=123
 

--- a/example.sh
+++ b/example.sh
@@ -3,7 +3,7 @@ set -e
 
 # either test against a local server or in a container testnet
 #export SERVER_ROOT=https://localhost
-export SERVER_ROOT=https://server
+export SERVER_ROOT=https://alice.localhost:8443 #https://server
 export USERNAME_ALICE=alice
 export PASSWORD_ALICE=123
 

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -167,7 +167,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', resourceUrl),
+        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -300,7 +300,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', resourceUrl),
+        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -491,7 +491,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Read, acl:Control', resourceUrl),
+        body: makeBody(null, 'acl:Read, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'
@@ -620,7 +620,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(containerUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', resourceUrl),
+        body: makeBody(null, 'acl:Read, acl:Append, acl:Control', containerUrl),
         headers: {
           'Content-Type': 'text/turtle',
           'If-None-Match': '*'


### PR DESCRIPTION
some container acl's where using resourceUrl
After the change all tests pass on NSS.

The fact that recursiveDelete works on update tests is due to the fact that the resource tree is the same on all tests.