### PR TITLE
Minor fixes and align new read tests with others

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     testEnvironment: 'node',
     verbose: false,
     collectCoverage: false,
+    testTimeout: 10000,
     globals: {
         'ts-jest': {
             // reference: https://kulshekhar.github.io/ts-jest/user/config/

--- a/test/surface/investigate.test.ts
+++ b/test/surface/investigate.test.ts
@@ -1,7 +1,0 @@
-import { SolidLogic } from 'solid-logic';
-import { generateTestFolder, getSolidLogicInstance, WEBID_ALICE, WEBID_BOB } from '../helpers/env';
-test.skip('investigate', async () => {
-  const solidLogicAlice = await getSolidLogicInstance('ALICE');
-  const result = await solidLogicAlice.fetch(`http://localhost:3000/.acl`);
-  console.log(result.status, await result.text());
-})

--- a/test/surface/investigate.test.ts
+++ b/test/surface/investigate.test.ts
@@ -1,6 +1,6 @@
 import { SolidLogic } from 'solid-logic';
 import { generateTestFolder, getSolidLogicInstance, WEBID_ALICE, WEBID_BOB } from '../helpers/env';
-test('investigate', async () => {
+test.skip('investigate', async () => {
   const solidLogicAlice = await getSolidLogicInstance('ALICE');
   const result = await solidLogicAlice.fetch(`http://localhost:3000/.acl`);
   console.log(result.status, await result.text());

--- a/test/surface/read-logged_in.test.ts
+++ b/test/surface/read-logged_in.test.ts
@@ -33,7 +33,7 @@ function makeBody(accessToModes: string, defaultModes: string, target: string) {
   return str
 }
 
-describe('Read', () => {
+describe('Read-LoggedIn', () => {
   let solidLogicAlice: SolidLogic;
   let solidLogicBob: SolidLogic;
   beforeAll(async () => {
@@ -68,7 +68,7 @@ describe('Read', () => {
       body: makeBody('acl:Read', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl)
@@ -93,7 +93,7 @@ describe('Read', () => {
       body: makeBody('acl:Append, acl:Write, acl:Control', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -117,7 +117,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Read', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -141,7 +141,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Append, acl:Write, acl:Control', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -165,7 +165,7 @@ describe('Read', () => {
       body: makeBody('acl:Read', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -189,7 +189,7 @@ describe('Read', () => {
       body: makeBody('acl:Append, acl:Write, acl:Control', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -214,7 +214,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Read', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -239,7 +239,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Append, acl:Write, acl:Control', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);

--- a/test/surface/read-public.test.ts
+++ b/test/surface/read-public.test.ts
@@ -35,7 +35,7 @@ function makeBody(accessToModes: string, defaultModes: string, target: string) {
   return str
 }
 
-describe('Read', () => {
+describe('Read-Public', () => {
   let solidLogicAlice: SolidLogic;
   let solidLogicBob
   beforeAll(async () => {
@@ -70,7 +70,7 @@ describe('Read', () => {
       body: makeBody('acl:Read', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -95,7 +95,7 @@ describe('Read', () => {
       body: makeBody('acl:Append, acl:Write, acl:Control', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -119,7 +119,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Read', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -143,7 +143,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Append, acl:Write, acl:Control', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -167,7 +167,7 @@ describe('Read', () => {
       body: makeBody('acl:Read', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -191,7 +191,7 @@ describe('Read', () => {
       body: makeBody('acl:Append, acl:Write, acl:Control', null, resourceUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -216,7 +216,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Read', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);
@@ -241,7 +241,7 @@ describe('Read', () => {
       body: makeBody(null, 'acl:Append, acl:Write, acl:Control', containerUrl),
       headers: {
         'Content-Type': 'text/turtle',
-        'If-None-Match': '*'
+        // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs
       }
     });
     const result = await solidLogicBob.fetch(resourceUrl);

--- a/test/surface/update.test.ts
+++ b/test/surface/update.test.ts
@@ -360,7 +360,7 @@ describe('Update', () => {
       const aclDocUrl = await solidLogicAlice.findAclDocUrl(resourceUrl);
       await solidLogicAlice.fetch(aclDocUrl, {
         method: 'PUT',
-        body: makeBody('acl:Write', null, resourceUrl),
+        body: makeBody('acl:Append', null, resourceUrl),
         headers: {
           'Content-Type': 'text/turtle',
           // 'If-None-Match': '*' - work around a bug in some servers that don't support If-None-Match on ACL doc URLs


### PR DESCRIPTION
I had failures due to the etag issue when accessing the ACL so commented out as in other read tests, but also renamed the top level as you couldn't see which test failed since they had the same names.